### PR TITLE
fix: add support for running on Linux ARM64 machines

### DIFF
--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -494,7 +494,7 @@ provider %[1]q {
 		return nil, err
 	}
 
-	tfBin, err := tfinstall.Find(ctx, tfinstall.ExactVersion("0.13.2", tmpDir))
+	tfBin, err := tfinstall.Find(ctx, tfinstall.ExactVersion("0.13.5", tmpDir))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Bumps the installed Terraform version to 0.13.5, which has an arm64 build for Linux

re #41